### PR TITLE
Fix xterm -e handling with multiword queryes

### DIFF
--- a/data/gmrunrc
+++ b/data/gmrunrc
@@ -47,14 +47,14 @@ SHELL_RUN = 1
 #   - %u gets replaced with the whole URL ("http://www.google.com")
 #   - %s gets replaced with "//www.google.com".  This is useful for URL-s
 #     like "man:printf" --> %s will get replaced with "printf"
-URL_http = xdg-open %u
-URL_mailto = xdg-email %u
-URL_file = xdg-open %s
-URL_man = ${TermExec} 'man %s'
-URL_info = ${TermExec} 'info %s'
+URL_http = xdg-open '%u'
+URL_mailto = xdg-email '%u'
+URL_file = xdg-open '%s'
+URL_man = ${TermExec} man %s
+URL_info = ${TermExec} info %s
 URL_search = xdg-open 'http://www.google.com/search?q=%s'
 
 # extension handlers
 # Customize your own extension handler.
-EXT:doc,rtf,txt,cc,cpp,h,java,html,htm,epl,tex,latex,js,css,xml,xsl,am,ps,pdf = xdg-open %s
+EXT:doc,rtf,txt,cc,cpp,h,java,html,htm,epl,tex,latex,js,css,xml,xsl,am,ps,pdf = xdg-open '%s'
 


### PR DESCRIPTION
* `xterm`'s `-e` option is an option with a **variable number of parameters*.
  It does not perform word splitting on its own and takes all argv's words
  after it.  Therefore, the quotation marks in `man` and `info` prevent you from
  passing them switches and multiple arguments. `man:` and `info:` handlers
  does not works, because there is no such binary - 'man \<arg\>' and 'info \<arg\>'...

* Some commands (like `xdg`-gues) takes 1 argument and they can contain
  shell-symbols -> must be braced

* Some of them (like man & info) can take multiple arguments and (as it seems
  to me) cannot contain shell-symbloc -> must not be braced to split query to
  multiple words.