### PR TITLE
add xdg compliant option for config and history files path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AC_ARG_ENABLE(xdg,
               AS_HELP_STRING([--enable-xdg],[follow xdg spec for configuration and history files location]),[],
    enable_xdg=no)
 
-if [ test "x$enable_popt" != "xyes"]; then
+if test "x$enable_popt" != "xyes"; then
    CFLAGS="$CFLAGS -DFOLLOW_XDG_SPEC"
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,14 @@ PKG_CHECK_MODULES([GTK], [$gtk_modules], [], [AC_ERROR([$errmsg])])
 AC_SUBST([GTK_CFLAGS])
 AC_SUBST([GTK_LIBS])
 
+AC_ARG_ENABLE(xdg,
+              AS_HELP_STRING([--enable-xdg],[follow xdg spec for configuration and history files location]),[],
+   enable_xdg=no)
+
+if [ test "x$enable_popt" != "xyes"]; then
+   CFLAGS="$CFLAGS -DFOLLOW_XDG_SPEC"
+fi
+
 #========================================================================
 
 case "$CC" in

--- a/src/config_prefs.c
+++ b/src/config_prefs.c
@@ -239,16 +239,22 @@ void config_init ()
       return;
    }
    char config_file[512];
-   char * HOME;
 
    snprintf (config_file, sizeof (config_file), "/etc/%s", APP_CONFIG_FILE);
    config_load_from_file (config_file, &PrefsGList);
 
+#ifdef FOLLOW_XDG_SPEC
+   const gchar *config_home = g_get_user_config_dir ();
+   snprintf (config_file, sizeof (config_file), "%s/%s", config_home, APP_CONFIG_FILE);
+   config_load_from_file (config_file, &PrefsGList);
+#else
+   char * HOME;
    HOME = getenv ("HOME");
    if (HOME) {
       snprintf (config_file, sizeof (config_file), "%s/.%s", HOME, APP_CONFIG_FILE);
       config_load_from_file (config_file, &PrefsGList);
    }
+#endif
 
    create_extension_handler_list ();
 }

--- a/src/gtkcompletionline.c
+++ b/src/gtkcompletionline.c
@@ -31,7 +31,7 @@
 #include "config_prefs.h"
 #include "gtkcompletionline.h"
 
-#define HISTORY_FILE ".gmrun_history"
+#define HISTORY_FILE "gmrun_history"
 
 static int on_cursor_changed_handler = 0;
 static int on_key_press_handler = 0;
@@ -223,11 +223,16 @@ static void gtk_completion_line_init (GtkCompletionLine *self)
    g_signal_connect(G_OBJECT(self), "scroll-event",
                     G_CALLBACK(on_scroll), NULL);
 
-   char * HOME = getenv ("HOME");
    char history_file[512] = "";
+#ifdef FOLLOW_XDG_SPEC
+   const gchar * history_dir = g_get_user_cache_dir ();
+   snprintf (history_file, sizeof (history_file), "%s/%s", history_dir, HISTORY_FILE);
+#else
+   char * HOME = getenv ("HOME");
    if (HOME) {
-      snprintf (history_file, sizeof (history_file), "%s/%s", HOME, HISTORY_FILE);
+      snprintf (history_file, sizeof (history_file), "%s/.%s", HOME, HISTORY_FILE);
    }
+#endif
 
    int HIST_MAX_SIZE;
    if (!config_get_int ("History", &HIST_MAX_SIZE))

--- a/src/history.c
+++ b/src/history.c
@@ -141,7 +141,7 @@ void _history_write_to_file (HistoryFile * history, const char * filename)
 //                     PUBLIC
 // ============================================================
 
-HistoryFile * history_new (char * filename, unsigned int maxcount)
+HistoryFile * history_new (const char * filename, unsigned int maxcount)
 {
    HistoryFile * history = calloc (1, sizeof (HistoryFile));
    history->max = maxcount;

--- a/src/history.h
+++ b/src/history.h
@@ -34,7 +34,7 @@ enum
 /// create a new HistoryFile
 /// the history is initialized using filename and the filename is stored
 /// maxcount > 0 sets a maximun item count
-HistoryFile * history_new (char * filename, unsigned int maxcount);
+HistoryFile * history_new (const char * filename, unsigned int maxcount);
 
 /// save history to file, 0 = force save / 1 = save only if history has changed
 void history_save (HistoryFile * history, int save_if_changed);


### PR DESCRIPTION
as said yersterday, I added a small option to allow conf and history file location to be xdg compliant.

Do you (both contributors), use to chat on some irc channel from time to time.
Would be nice to have small "meeting", I'm quite always connected to freenode as mazes_80, a private msg wouldn't be lost even if async